### PR TITLE
Build android app with sdk error

### DIFF
--- a/app/src/main/java/com/cgj/app/MainActivity.kt
+++ b/app/src/main/java/com/cgj/app/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.Image


### PR DESCRIPTION
Add missing import for `fillMaxWidth` to resolve a compilation error.

The `fillMaxWidth()` modifier was used in `MainActivity.kt` but its corresponding import was missing, leading to a compilation failure during the Android build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-82a36053-f6b6-4cd1-a7de-a27408dc45a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82a36053-f6b6-4cd1-a7de-a27408dc45a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

