### PR TITLE
Fix kotlin type and overload errors

### DIFF
--- a/app/src/main/java/com/cgj/app/MainActivity.kt
+++ b/app/src/main/java/com/cgj/app/MainActivity.kt
@@ -547,7 +547,7 @@ fun SubstitutionScreen(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInput(Unit) {
-                        detectTransformGestures { _, pan, zoom, _ ->
+                        detectTransformGestures { _, pan: androidx.compose.ui.geometry.Offset, zoom: Float, _ ->
                             scale = (lastScale * zoom).coerceIn(1f, 5f)
                             offsetX = (lastOffsetX + pan.x).coerceIn(-1000f, 1000f)
                             offsetY = (lastOffsetY + pan.y).coerceIn(-1000f, 1000f)
@@ -916,3 +916,6 @@ private fun PDFView.loadPdf(url: String, onLoadComplete: () -> Unit) {
         }
     }
 }
+
+private fun androidx.compose.ui.input.pointer.PointerInputChange.changedToUp(): Boolean =
+    this.previousPressed && !this.pressed


### PR DESCRIPTION
Fix compilation errors by adding explicit types and a missing extension function.

The compiler errors stemmed from Kotlin's inability to infer types for parameters in `detectTransformGestures` and ambiguity in float operations, which were resolved by explicitly specifying `Offset` and `Float` types. Additionally, an unresolved reference to `changedToUp` was fixed by adding a private extension function.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d956d34-e1ee-4768-b514-95f6946aa907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d956d34-e1ee-4768-b514-95f6946aa907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

