### PR TITLE
Fix MainActivity compilation errors

### DIFF
--- a/app/src/main/java/com/cgj/app/MainActivity.kt
+++ b/app/src/main/java/com/cgj/app/MainActivity.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.input.pointer.pointerEvent
 import androidx.compose.ui.input.pointer.pointerEventScope
 import androidx.compose.ui.input.pointer.detectTransformGestures
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.graphics.graphicsLayer
 import android.provider.MediaStore
 import android.widget.Toast


### PR DESCRIPTION
Add missing `PointerInputChange` import to resolve compilation errors related to the `changedToUp()` extension function.

---
<a href="https://cursor.com/background-agent?bcId=bc-10f683f5-6d36-43ce-8214-b25360dd782b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10f683f5-6d36-43ce-8214-b25360dd782b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

